### PR TITLE
[Bug-example][DO NOT MERGE] MaxLineLength excludeRawStrings

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -4,9 +4,9 @@ formatting:
   # ExampleAdapter.onCreateViewHolder is not working when we remove option below.
   # Exceeded max line length (120) [MaximumLineLength]
   # https://github.com/detekt/detekt/issues/7551
-  MaximumLineLength:
-    active: true
-    maxLineLength: 130
+  #  MaximumLineLength:
+  #    active: true
+  #    maxLineLength: 130
   ArgumentListWrapping:
     active: true
     maxLineLength: 130
@@ -25,6 +25,7 @@ formatting:
   TypeParameterListSpacing:
     active: true
 style:
+  # `excludeRawStrings: true` is set here
   MaxLineLength:
     active: true
     maxLineLength: 130

--- a/sample/src/main/kotlin/pl/beavercoding/viewbindingdelegate/ExampleAdapter.kt
+++ b/sample/src/main/kotlin/pl/beavercoding/viewbindingdelegate/ExampleAdapter.kt
@@ -13,7 +13,8 @@ internal class ExampleAdapter(
     private val onExampleClicked: OnExampleClicked,
 ) : ListAdapter<Example, ExampleAdapter.ExampleViewHolder>(DiffCallback()) {
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) = ExampleViewHolder.create(parent, onExampleClicked)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+        ExampleViewHolder.create(parent, onExampleClicked)
 
     override fun onBindViewHolder(holder: ExampleViewHolder, position: Int) = holder.bind(getItem(position))
 

--- a/sample/src/main/kotlin/pl/beavercoding/viewbindingdelegate/ExampleFragment3.kt
+++ b/sample/src/main/kotlin/pl/beavercoding/viewbindingdelegate/ExampleFragment3.kt
@@ -22,6 +22,11 @@ internal class ExampleFragment3 : Fragment(R.layout.fragment_example_3) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.helloWorld.text = getString(R.string.example_3)
+        binding.helloWorld.text = TEST_STRING
+    }
+
+    companion object {
+        private const val TEST_STRING =
+            """C:\Repository\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\test\some_file.pdf"""
     }
 }


### PR DESCRIPTION
## Description
<!-- fill that briefly -->
**DO NOT MERGE.** Added an example to demonstrate that the `excludeRawStrings` option in `MaxLineLength` does not correctly ignore raw strings. The current configuration does not bypass raw strings when calculating line length, leading to unexpected linting failures. It works fine only when closing quote signs are in new line.

## Issue ticket number and link
https://github.com/detekt/detekt/issues/7555

## Checklist
- [ ] Code is formatted properly
- [ ] I have performed a self-review of my code
- [ ] Tests passed successfully, and new ones were added if necessary
